### PR TITLE
Provide access to data in overridden WooCommerce templates

### DIFF
--- a/src/woocommerce.php
+++ b/src/woocommerce.php
@@ -28,7 +28,11 @@ if (defined('WC_ABSPATH')) {
 
         // Don't render template when used in REST
         if ($theme_template && !(defined('REST_REQUEST') && REST_REQUEST)) {
-            echo template($theme_template, $args);
+            $data = collect(get_body_class())->reduce(function ($data, $class) use ($template) {
+                return apply_filters("sage/template/{$class}/data", $data, $template);
+            }, []);
+
+            echo template($theme_template, array_merge($data, $args));
             return get_stylesheet_directory() . '/index.php';
         }
 


### PR DESCRIPTION
When a blade template includes a partial, the partial is given access to all of the same data as the template that included it.

WooCommerce templates may be overridden in the `/resources/views/woocommerce/` folder however when `wc_get_template` is called, the data isn't passed in. This means that it won't have access to the same variables as if it was called with `@include('woocommerce. ...`.

I discovered the issue while working on the single product page. I'd overridden the share template (woocommerce/single-product/share.blade.php) which was loaded in via a hook. As such I wasn't able to get access to the same variables from the controller.

The same code should probably also apply to the `wc_get_template_part` filter but I was torn on how best to handle it. It may make sense to turn it into a reusable function but at that point, it probably belongs in the main theme and not the WooCommerce helper.