### PR TITLE
wc_get_template enhancements

### DIFF
--- a/examples/resources/views/woocommerce/archive-product.blade.php
+++ b/examples/resources/views/woocommerce/archive-product.blade.php
@@ -1,3 +1,19 @@
+{{--
+The Template for displaying product archives, including the main shop page which is a post type archive
+
+This template can be overridden by copying it to yourtheme/woocommerce/archive-product.php.
+
+HOWEVER, on occasion WooCommerce will need to update template files and you
+(the theme developer) will need to copy the new files to your theme to
+maintain compatibility. We try to do this as little as possible, but it does
+happen. When this occurs the version of the template file will be bumped and
+the readme will list any important changes.
+
+@see https://docs.woocommerce.com/document/template-structure/
+@package WooCommerce/Templates
+@version 3.4.0
+--}}
+
 @extends('layouts.app')
 
 @section('content')

--- a/examples/resources/views/woocommerce/single-product.blade.php
+++ b/examples/resources/views/woocommerce/single-product.blade.php
@@ -1,3 +1,20 @@
+{{--
+The Template for displaying all single products
+
+This template can be overridden by copying it to yourtheme/woocommerce/single-product.php.
+
+HOWEVER, on occasion WooCommerce will need to update template files and you
+(the theme developer) will need to copy the new files to your theme to
+maintain compatibility. We try to do this as little as possible, but it does
+happen. When this occurs the version of the template file will be bumped and
+the readme will list any important changes.
+
+@see 	    https://docs.woocommerce.com/document/template-structure/
+@author 		WooThemes
+@package 	WooCommerce/Templates
+@version     1.6.4
+--}}
+
 @extends('layouts.app')
 
 @section('content')

--- a/src/woocommerce.php
+++ b/src/woocommerce.php
@@ -9,11 +9,11 @@ if (defined('WC_ABSPATH')) {
     add_filter('template_include', function ($template) {
         return strpos($template, WC_ABSPATH) === -1
             ? $template
-            : locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
+            : locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
     }, 100, 1);
 
     add_filter('wc_get_template_part', function ($template) {
-        $theme_template = locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template));
+        $theme_template = locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template));
 
         if ($theme_template) {
             $data = collect(get_body_class())->reduce(function ($data, $class) {
@@ -28,7 +28,7 @@ if (defined('WC_ABSPATH')) {
     }, PHP_INT_MAX, 1);
 
     add_action('woocommerce_before_template_part', function($template_name, $template_path, $located, $args) {
-        $theme_template = locate_template('woocommerce/' . $template_name);
+        $theme_template = locate_template(WC()->template_path() . $template_name);
 
         if ($theme_template) {
             $data = collect(get_body_class())->reduce(function ($data, $class) {
@@ -44,7 +44,7 @@ if (defined('WC_ABSPATH')) {
     }, PHP_INT_MAX, 4);
 
     add_filter('wc_get_template', function ($template, $template_name, $args) {
-        $theme_template = locate_template('woocommerce/' . $template_name);
+        $theme_template = locate_template(WC()->template_path() . $template_name);
 
         // return theme filename for status screen
         if (is_admin() && function_exists('get_current_screen') && get_current_screen()->id === 'woocommerce_page_wc-status') {


### PR DESCRIPTION
- Add rendering to `woocommerce_before_template_part` hook (inspiration in https://github.com/kimhf/sage-woocommerce-support)
- Add local variables to template #6
- Render only when not in status screen #9
- Provide data access as suggested in #8 
- Do not hardcode '/woocommerce' as WooCommerce template folder #11