### PR TITLE
Do not hardcode '/woocommerce' as WooCommerce template folder

### DIFF
--- a/src/woocommerce.php
+++ b/src/woocommerce.php
@@ -9,11 +9,11 @@ if (defined('WC_ABSPATH')) {
     add_filter('template_include', function ($template) {
         return strpos($template, WC_ABSPATH) === -1
             ? $template
-            : locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
+            : locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
     }, 100, 1);
 
     add_filter('wc_get_template_part', function ($template) {
-        $theme_template = locate_template('woocommerce/' . str_replace(WC_ABSPATH . 'templates/', '', $template));
+        $theme_template = locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template));
 
         if ($theme_template) {
             echo template($theme_template);
@@ -24,7 +24,7 @@ if (defined('WC_ABSPATH')) {
     }, PHP_INT_MAX, 1);
 
     add_filter('wc_get_template', function ($template, $template_name, $args) {
-        $theme_template = locate_template('woocommerce/' . $template_name);
+        $theme_template = locate_template(WC()->template_path() . $template_name);
 
         // Don't render template when used in REST
         if ($theme_template && !(defined('REST_REQUEST') && REST_REQUEST)) {


### PR DESCRIPTION
WC allows to change the default (/woocommerce) template folder to something like /shop. `WC()->template_path()` defaults to /woocommerce so if that is not customized, it fallback to the default. This PR is for some more flexibility.