### PR TITLE
Enable overriding `single-product-reviews` template

### DIFF
--- a/src/woocommerce.php
+++ b/src/woocommerce.php
@@ -6,11 +6,18 @@ if (defined('WC_ABSPATH')) {
         add_theme_support('woocommerce');
     });
 
-    add_filter('template_include', function ($template) {
+    /**
+     * @param string $template
+     * @return string
+     */
+    function wc_template_loader(String $template)
+    {
         return strpos($template, WC_ABSPATH) === -1
             ? $template
             : locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template)) ? : $template;
-    }, 100, 1);
+    }
+    add_filter('template_include', __NAMESPACE__ . '\\wc_template_loader', 100, 1);
+    add_filter('comments_template', __NAMESPACE__ . '\\wc_template_loader', 100, 1);
 
     add_filter('wc_get_template_part', function ($template) {
         $theme_template = locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template));

--- a/src/woocommerce.php
+++ b/src/woocommerce.php
@@ -9,7 +9,7 @@ if (defined('WC_ABSPATH')) {
     add_filter('template_include', function ($template) {
         return strpos($template, WC_ABSPATH) === -1
             ? $template
-            : locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template)) ?: $template;
+            : locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template)) ? : $template;
     }, 100, 1);
 
     add_filter('wc_get_template_part', function ($template) {
@@ -27,7 +27,7 @@ if (defined('WC_ABSPATH')) {
         return $template;
     }, PHP_INT_MAX, 1);
 
-    add_action('woocommerce_before_template_part', function($template_name, $template_path, $located, $args) {
+    add_action('woocommerce_before_template_part', function ($template_name, $template_path, $located, $args) {
         $theme_template = locate_template(WC()->template_path() . $template_name);
 
         if ($theme_template) {
@@ -48,7 +48,7 @@ if (defined('WC_ABSPATH')) {
 
         // return theme filename for status screen
         if (is_admin() && function_exists('get_current_screen') && get_current_screen()->id === 'woocommerce_page_wc-status') {
-            return $theme_template ?: $template;
+            return $theme_template ? : $template;
         }
 
         // return empty file, output already rendered by 'woocommerce_before_template_part' hook


### PR DESCRIPTION
Enable overriding `single-product-reviews` template by filtering `comments_template`.

Also makes minor formatting changes to meet the PSR-2 standard used in Roots projects.

Resolves the issue raised here: https://discourse.roots.io/t/cant-override-template-single-product-reviews-php/13421