### PR TITLE
Return theme filename for status screen when get_current_screen is not null.

### DIFF
--- a/src/woocommerce.php
+++ b/src/woocommerce.php
@@ -54,7 +54,7 @@ if (defined('WC_ABSPATH')) {
         $theme_template = locate_template(WC()->template_path() . $template_name);
 
         // return theme filename for status screen
-        if (is_admin() && ! wp_doing_ajax() && function_exists('get_current_screen') && get_current_screen()->id === 'woocommerce_page_wc-status') {
+        if (is_admin() && ! wp_doing_ajax() && function_exists('get_current_screen') && get_current_screen() && get_current_screen()->id === 'woocommerce_page_wc-status') {
             return $theme_template ? : $template;
         }
 


### PR DESCRIPTION
get_current_screen may return WP_Screen|null 
@link https://developer.wordpress.org/reference/functions/get_current_screen/