### PR TITLE
Change PHP to Blade for page title

### DIFF
--- a/examples/resources/views/woocommerce/archive-product.blade.php
+++ b/examples/resources/views/woocommerce/archive-product.blade.php
@@ -24,7 +24,7 @@ the readme will list any important changes.
 
   <header class="woocommerce-products-header">
     @if(apply_filters('woocommerce_show_page_title', true))
-      <h1 class="woocommerce-products-header__title page-title"><?php woocommerce_page_title(); ?></h1>
+      <h1 class="woocommerce-products-header__title page-title">{{ woocommerce_page_title() }}</h1>
     @endif
 
     @php


### PR DESCRIPTION
Change the PHP syntax of the page title used within the `<h1>` to use Blade syntax instead.