### PR TITLE
Use parantheses for nested ternary

### DIFF
--- a/src/woocommerce.php
+++ b/src/woocommerce.php
@@ -14,7 +14,7 @@ if (defined('WC_ABSPATH')) {
     {
         return strpos($template, WC_ABSPATH) === -1
             ? $template
-            : locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template)) ? : $template;
+            : (locate_template(WC()->template_path() . str_replace(WC_ABSPATH . 'templates/', '', $template)) ? : $template);
     }
     add_filter('template_include', __NAMESPACE__ . '\\wc_template_loader', 100, 1);
     add_filter('comments_template', __NAMESPACE__ . '\\wc_template_loader', 100, 1);


### PR DESCRIPTION
[PHP 7.4 deprecates using ternary operators without explicit parantheses](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary), this PR will fix it and stop the extension from outputting notices.